### PR TITLE
Support keyboard input

### DIFF
--- a/example/page.html
+++ b/example/page.html
@@ -26,6 +26,7 @@
 <body>
     <div id="monitor-frame-container"></div>
     <div id="explanation">
+    <input></input>
     <h1><span>Welcome to the future!</span></h1>
     <p><span>You should be able to—
         <ul>
@@ -41,6 +42,11 @@
     <p><span><strong>Otherwise</strong>, enjoy!</span></p>
     </div>
     <script>
+
+        const html = document.getElementsByTagName('html')[0]
+        document.addEventListener('keydown', e => console.log(e.code))
+        window.onfocus = () => console.log("focused")
+        window.onblur = () => console.log("blurred")
 
         // Async wrapper necessary so we can use `await`
         ;(async () => {

--- a/main.c
+++ b/main.c
@@ -392,6 +392,48 @@ void printUsage(char *programName) {
         programName);
 }
 
+// Listen for the "pointer entered window" and "pointer left window" events,
+// and in response grab or ungrab the keyboard device.
+//
+// This is necessary because our overlay window has the override_redirect flag
+// set, meaning while it can get pointer events, the desktop environment will
+// never give it keyboard events.  It can however *grab the keyboard device*
+// itself, effectively taking keyboard input focus instead of being given it.
+// So we do that.
+struct PointerEnterEventData {
+    GdkSeat *seat;
+    GdkWindow *window;
+};
+gboolean on_pointer_enter_window(
+        GtkWidget *widget, GdkEventCrossing *event, gpointer user_data) {
+    struct PointerEnterEventData *data =
+        (struct PointerEnterEventData *) user_data;
+    printf("Pointer entered window.  Grabbing.\n");
+    gdk_seat_grab(data->seat, data->window,
+            // Grab the keyboard only we already get pointer events.
+            GDK_SEAT_CAPABILITY_KEYBOARD,
+            FALSE, // owner events
+            NULL,  // cursor
+            // event that triggered the grab: Internally, gdk_seat_grab uses
+            // XIGrabDevice, which reads the event's timestamp.  The grab
+            // request is cancelled if the given event happened before the last
+            // device grab.  This makes stuff happen in the expected order when
+            // under heavy system load, where events may be handled with
+            // significant delay.
+            (GdkEvent *) event,
+            NULL,  // prepare func (don't need it; window is visible already)
+            NULL   // user_data passed to prepare func
+            );
+    return FALSE;
+}
+gboolean on_pointer_leave_window(
+        GtkWidget *widget, GdkEventCrossing *event, gpointer user_data) {
+    GdkSeat *seat = (GdkSeat *) user_data;
+    printf("Pointer left window.  Releasing grab.\n");
+    gdk_seat_ungrab(seat);
+    return FALSE;
+}
+
 int main(int argc, char **argv) {
 
     gtk_init(&argc, &argv);
@@ -661,6 +703,22 @@ next:
     g_signal_connect(G_OBJECT(window), "delete-event", gtk_main_quit, NULL);
     gtk_widget_set_app_paintable(window, TRUE);
 
+    // Listen for enter and leave notify events.
+    //
+    // These are fired when the mouse pointer enters the overlay window.  They
+    // won't fire by default (because it has no input-area), but will fire if
+    // JS has called `Hudkit.setClickableAreas`, and the mouse pointer enters
+    // one of those areas.
+    GdkDisplay *display = gdk_display_get_default();
+    GdkSeat *seat = gdk_display_get_default_seat(display);
+    gtk_widget_set_events(window,
+            GDK_ENTER_NOTIFY_MASK & GDK_LEAVE_NOTIFY_MASK);
+    struct PointerEnterEventData pointer_enter_event_data = { seat };
+    g_signal_connect (window, "enter-notify-event",
+            G_CALLBACK(on_pointer_enter_window), &pointer_enter_event_data);
+    g_signal_connect (window, "leave-notify-event",
+            G_CALLBACK(on_pointer_leave_window), seat);
+
     //
     // Set up the WebKit web view widget
     //
@@ -729,7 +787,6 @@ next:
     // it correctly.
     screen_changed(window, NULL, web_view);
 
-    GdkDisplay *display = gdk_display_get_default();
     GdkRectangle *rectangles = NULL;
     int nRectangles = get_monitor_rects(display, &rectangles);
 
@@ -738,6 +795,7 @@ next:
     // Hide the window, so we can get our properties ready without the window
     // manager trying to mess with us.
     GdkWindow *gdk_window = gtk_widget_get_window(GTK_WIDGET(window));
+    pointer_enter_event_data.window = gdk_window;
     gdk_window_hide(GDK_WINDOW(gdk_window));
 
     // "Can't touch this!" - to the window manager


### PR DESCRIPTION
So I finally figured out how to make an `override_redirect` window get keyboard focus:  it has to grab the keyboard device itself.  https://github.com/anko/hudkit/commit/d40cb15eea00588c09e9deacc7af6bfa9cd07001 is an initial proof of concept that this works.  This draft PR is a dumping ground for thoughts and plans on how to proceed, toward something stable enough to release, as if I ever finished anything worthwhile.

If you check out the `grab-keyboard` branch and run the `example/`, the leftmost 100 pixels of column on your leftmost monitor should be a clickable area, and when you hover over it, you can also type text, which the webview can react to as you'd expect by listening to `keydown` events.


https://user-images.githubusercontent.com/5231746/116835815-66b4d980-abc4-11eb-86fe-8ebf362101ee.mp4

Incidentally, this also makes it possible to type into the Web Inspector also when it is docked to the overlay window.

- - -

Bugs to be fixed:

- [ ] Drag-and-drop gets into a broken state when trying to drag selected text out of the overlay's clickable area.

  It would be real smooth if it were possible to drag and drop whatever across the boundary, but if it turns out to be too hard, just cancelling the drag and not breaking is still good enough to release.

- [ ] The window gets erroneously jittery enter/leave events when moving the mouse near the edges of the screen.

  A workaround that seems to work according to brief testing: Just make the window 1 pixel larger in every dimension than the desktop area, and position it so it's indistinguishable.  The event jitter only happens on the edge pixel.

- - -

Also have to think about the API design of this.  My plan so far is to add `Hudkit.grabKeyboard()`/`.ungrabKeyboard()` to the JS API, so user code can grab it when appropriate, instead of always.  You might for example want some elements to only be clickable, without grabbing keyboard focus when they are hovered, while others should grab keyboard focus.

The command line flag to control this could look like `--grab-keyboard` followed by

- `never`:  do not ever grab keyboard focus; related JS API does nothing
- `on-hover`:  always grab keyboard when clickable part of overlay is hovered; related JS API does nothing
- `on-js`:  enable the related JS API

Haven't decided what the default should be yet.